### PR TITLE
Add baseline for SIGIR task1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 This repository is created to host the Recommender Systems competitions solutions.
+
+For SIGIR eCommerce Challenge task 1 you can start with the simple baseline in `SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/baselines`.

--- a/SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/README.md
+++ b/SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/README.md
@@ -12,6 +12,10 @@ This repo includes Python code, scripts and instructions on how to run the pre-p
   <font size="1">Fig. 1 - Our base Transformer architecture</font>
 </p>
 
+## Baseline Models
+Simple reference baselines are available in the [baselines](baselines/) folder. The `popularity_baseline.py` script demonstrates predicting the most popular items for every session.
+
+
 ## Setup the environment
 
 The next sections describe two alternatives to setup the environment to run the pipelines: Docker and Conda.

--- a/SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/baselines/README.md
+++ b/SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/baselines/README.md
@@ -1,0 +1,21 @@
+# Baseline Solutions for Task 1
+
+This folder contains simple reference implementations for the session-based recommendation task.
+The goal is to provide lightweight starting points before moving to the complex Transformer-based models used in our final solution.
+
+## Popularity Baseline
+The `popularity_baseline.py` script computes the most popular items in the training data and recommends the top items for every session.
+It requires the input interactions in CSV format with an `product_id` column.
+
+### Train
+```bash
+python popularity_baseline.py train train_interactions.csv popularity.csv
+```
+
+### Predict
+```bash
+python popularity_baseline.py predict popularity.csv predictions.json --top-k 20
+```
+The prediction file will contain a JSON array with the same list of top items for every session.
+
+These baselines can be extended with more sophisticated logic (e.g. item bigrams or session-aware heuristics) as needed.

--- a/SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/baselines/popularity_baseline.py
+++ b/SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/baselines/popularity_baseline.py
@@ -1,0 +1,64 @@
+import argparse
+import json
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+
+
+def compute_item_popularity(df: pd.DataFrame, item_col: str) -> pd.Series:
+    """Return item popularity sorted descending."""
+    return df[item_col].value_counts()
+
+
+def train(train_path: Path, item_col: str, output_path: Path) -> None:
+    df = pd.read_csv(train_path)
+    popularity = compute_item_popularity(df, item_col)
+    popularity.to_csv(output_path, header=False)
+    print(f"Saved popularity counts to {output_path}")
+
+
+def load_popularity(popularity_path: Path) -> pd.Series:
+    pop = pd.read_csv(popularity_path, header=None, names=['item', 'count'])
+    return pop.set_index('item')['count']
+
+
+def predict_sessions(popularity: pd.Series, top_k: int) -> List[List[int]]:
+    top_items = popularity.sort_values(ascending=False).head(top_k).index.tolist()
+    return [top_items]
+
+
+def predict(popularity_path: Path, output_path: Path, top_k: int) -> None:
+    popularity = load_popularity(popularity_path)
+    predictions = predict_sessions(popularity, top_k)
+    with open(output_path, 'w') as f:
+        json.dump(predictions, f)
+    print(f"Saved predictions to {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Popularity baseline")
+    subparsers = parser.add_subparsers(dest="command")
+
+    train_parser = subparsers.add_parser("train")
+    train_parser.add_argument("train_path", type=Path, help="Training CSV file")
+    train_parser.add_argument("output_path", type=Path, help="Path to save popularity counts")
+    train_parser.add_argument("--item-col", default="product_id", help="Column with item id")
+
+    predict_parser = subparsers.add_parser("predict")
+    predict_parser.add_argument("popularity_path", type=Path, help="Popularity file from training")
+    predict_parser.add_argument("output_path", type=Path, help="Path to save predictions JSON")
+    predict_parser.add_argument("--top-k", type=int, default=20)
+
+    args = parser.parse_args()
+
+    if args.command == "train":
+        train(args.train_path, args.item_col, args.output_path)
+    elif args.command == "predict":
+        predict(args.popularity_path, args.output_path, args.top_k)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce a simple popularity baseline for SIGIR eCommerce task 1
- document how to run the baseline
- reference the baseline from main READMEs

## Testing
- `pytest -q` *(fails: command not found)*