### PR TITLE
Add PyTorch RNN baseline with common model interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 This repository is created to host the Recommender Systems competitions solutions.
 
-For SIGIR eCommerce Challenge task 1 you can start with the simple baseline in `SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/baselines`.
+For SIGIR eCommerce Challenge task 1 you can start with the baselines under `SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/baselines`.
+Both baselines expose the same command line interface so they can be swapped easily.

--- a/SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/baselines/README.md
+++ b/SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/baselines/README.md
@@ -9,13 +9,26 @@ It requires the input interactions in CSV format with an `product_id` column.
 
 ### Train
 ```bash
-python popularity_baseline.py train train_interactions.csv popularity.csv
+python popularity_baseline.py train train_interactions.csv popularity_model.pkl
 ```
 
 ### Predict
 ```bash
-python popularity_baseline.py predict popularity.csv predictions.json --top-k 20
+python popularity_baseline.py predict popularity_model.pkl predictions.json --top-k 20
 ```
 The prediction file will contain a JSON array with the same list of top items for every session.
+
+## GRU PyTorch Baseline
+The `rnn_baseline.py` script provides a minimal GRU-based model implemented with PyTorch. It shares the same command line interface as the popularity baseline and saves models to disk using `torch.save`.
+
+### Train
+```bash
+python rnn_baseline.py train train_interactions.csv rnn_model.pth --epochs 5
+```
+
+### Predict
+```bash
+python rnn_baseline.py predict rnn_model.pth interactions.csv predictions.json --top-k 20
+```
 
 These baselines can be extended with more sophisticated logic (e.g. item bigrams or session-aware heuristics) as needed.

--- a/SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/baselines/models.py
+++ b/SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/baselines/models.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict
+
+import pandas as pd
+import torch
+from torch import nn
+from torch.utils.data import Dataset, DataLoader
+
+
+class BaseModel:
+    """Common interface for baseline models."""
+
+    def train(self, *args, **kwargs) -> None:
+        raise NotImplementedError
+
+    def predict_sessions(self, sessions: List[List[int]], top_k: int) -> List[List[int]]:
+        raise NotImplementedError
+
+    def save(self, path: Path) -> None:
+        raise NotImplementedError
+
+    @classmethod
+    def load(cls, path: Path) -> "BaseModel":
+        raise NotImplementedError
+
+
+class PopularityModel(BaseModel):
+    """Simple popularity based model."""
+
+    def __init__(self, popularity: pd.Series | None = None) -> None:
+        self.popularity = popularity if popularity is not None else pd.Series(dtype=int)
+
+    def train(self, train_path: Path, item_col: str = "product_id") -> None:
+        df = pd.read_csv(train_path)
+        self.popularity = df[item_col].value_counts()
+
+    def predict_sessions(self, sessions: List[List[int]], top_k: int) -> List[List[int]]:
+        top_items = self.popularity.sort_values(ascending=False).head(top_k).index.tolist()
+        return [top_items for _ in sessions]
+
+    def save(self, path: Path) -> None:
+        self.popularity.to_csv(path, header=False)
+
+    @classmethod
+    def load(cls, path: Path) -> "PopularityModel":
+        pop = pd.read_csv(path, header=None, names=["item", "count"])
+        return cls(pop.set_index("item")["count"])
+
+
+class SessionDataset(Dataset):
+    def __init__(self, sessions: List[List[int]], item2idx: Dict[int, int], max_len: int = 20) -> None:
+        self.inputs = []
+        self.targets = []
+        self.max_len = max_len
+        for s in sessions:
+            idxs = [item2idx[i] for i in s if i in item2idx]
+            if len(idxs) < 2:
+                continue
+            self.inputs.append(idxs[:-1][-max_len:])
+            self.targets.append(idxs[-1])
+
+    def __len__(self) -> int:
+        return len(self.inputs)
+
+    def __getitem__(self, idx: int):
+        return self.inputs[idx], self.targets[idx]
+
+
+def collate_batch(batch):
+    seqs, targets = zip(*batch)
+    max_len = max(len(s) for s in seqs)
+    padded = [([0] * (max_len - len(s)) + s) for s in seqs]
+    return torch.tensor(padded, dtype=torch.long), torch.tensor(targets, dtype=torch.long)
+
+
+class GRURecModel(nn.Module):
+    def __init__(self, num_items: int, embedding_dim: int = 64, hidden_dim: int = 128) -> None:
+        super().__init__()
+        self.embedding = nn.Embedding(num_items, embedding_dim, padding_idx=0)
+        self.gru = nn.GRU(embedding_dim, hidden_dim, batch_first=True)
+        self.fc = nn.Linear(hidden_dim, num_items)
+
+    def forward(self, seq: torch.Tensor) -> torch.Tensor:
+        emb = self.embedding(seq)
+        _, h = self.gru(emb)
+        return self.fc(h.squeeze(0))
+
+
+class RNNRecModel(BaseModel):
+    """Simple GRU based next item predictor."""
+
+    def __init__(self, model: GRURecModel | None = None, item2idx: Dict[int, int] | None = None) -> None:
+        self.model = model
+        self.item2idx = item2idx or {}
+        self.idx2item = {v: k for k, v in (item2idx or {}).items()}
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if self.model is not None:
+            self.model.to(self.device)
+
+    def train(
+        self,
+        train_path: Path,
+        session_col: str = "session_id",
+        item_col: str = "product_id",
+        epochs: int = 5,
+        embedding_dim: int = 64,
+        hidden_dim: int = 128,
+    ) -> None:
+        df = pd.read_csv(train_path)
+        sessions = df.groupby(session_col)[item_col].apply(list).tolist()
+        unique_items = sorted({i for s in sessions for i in s})
+        self.item2idx = {item: idx + 1 for idx, item in enumerate(unique_items)}
+        self.idx2item = {v: k for k, v in self.item2idx.items()}
+        dataset = SessionDataset(sessions, self.item2idx)
+        self.model = GRURecModel(len(self.item2idx) + 1, embedding_dim, hidden_dim).to(self.device)
+        loader = DataLoader(dataset, batch_size=64, shuffle=True, collate_fn=collate_batch)
+        criterion = nn.CrossEntropyLoss()
+        optim = torch.optim.Adam(self.model.parameters())
+        self.model.train()
+        for _ in range(epochs):
+            for seq, target in loader:
+                seq = seq.to(self.device)
+                target = target.to(self.device)
+                optim.zero_grad()
+                out = self.model(seq)
+                loss = criterion(out, target)
+                loss.backward()
+                optim.step()
+
+    def predict_sessions(self, sessions: List[List[int]], top_k: int) -> List[List[int]]:
+        self.model.eval()
+        preds: List[List[int]] = []
+        with torch.no_grad():
+            for s in sessions:
+                idxs = [self.item2idx.get(i, 0) for i in s][-20:]
+                seq = torch.tensor([idxs], dtype=torch.long, device=self.device)
+                logits = self.model(seq)
+                top = logits.topk(top_k, dim=1).indices[0].tolist()
+                preds.append([self.idx2item.get(i, -1) for i in top])
+        return preds
+
+    def save(self, path: Path) -> None:
+        torch.save({"state_dict": self.model.state_dict(), "item2idx": self.item2idx}, path)
+
+    @classmethod
+    def load(cls, path: Path) -> "RNNRecModel":
+        data = torch.load(path, map_location="cpu")
+        model = GRURecModel(len(data["item2idx"]) + 1)
+        model.load_state_dict(data["state_dict"])
+        return cls(model=model, item2idx=data["item2idx"])

--- a/SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/baselines/popularity_baseline.py
+++ b/SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/baselines/popularity_baseline.py
@@ -5,57 +5,36 @@ from typing import List
 
 import pandas as pd
 
-
-def compute_item_popularity(df: pd.DataFrame, item_col: str) -> pd.Series:
-    """Return item popularity sorted descending."""
-    return df[item_col].value_counts()
+from models import PopularityModel
 
 
-def train(train_path: Path, item_col: str, output_path: Path) -> None:
-    df = pd.read_csv(train_path)
-    popularity = compute_item_popularity(df, item_col)
-    popularity.to_csv(output_path, header=False)
-    print(f"Saved popularity counts to {output_path}")
-
-
-def load_popularity(popularity_path: Path) -> pd.Series:
-    pop = pd.read_csv(popularity_path, header=None, names=['item', 'count'])
-    return pop.set_index('item')['count']
-
-
-def predict_sessions(popularity: pd.Series, top_k: int) -> List[List[int]]:
-    top_items = popularity.sort_values(ascending=False).head(top_k).index.tolist()
-    return [top_items]
-
-
-def predict(popularity_path: Path, output_path: Path, top_k: int) -> None:
-    popularity = load_popularity(popularity_path)
-    predictions = predict_sessions(popularity, top_k)
-    with open(output_path, 'w') as f:
-        json.dump(predictions, f)
-    print(f"Saved predictions to {output_path}")
-
-
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Popularity baseline")
     subparsers = parser.add_subparsers(dest="command")
 
     train_parser = subparsers.add_parser("train")
     train_parser.add_argument("train_path", type=Path, help="Training CSV file")
-    train_parser.add_argument("output_path", type=Path, help="Path to save popularity counts")
+    train_parser.add_argument("output_path", type=Path, help="Path to save model")
     train_parser.add_argument("--item-col", default="product_id", help="Column with item id")
 
     predict_parser = subparsers.add_parser("predict")
-    predict_parser.add_argument("popularity_path", type=Path, help="Popularity file from training")
+    predict_parser.add_argument("model_path", type=Path, help="Trained model file")
     predict_parser.add_argument("output_path", type=Path, help="Path to save predictions JSON")
     predict_parser.add_argument("--top-k", type=int, default=20)
 
     args = parser.parse_args()
 
     if args.command == "train":
-        train(args.train_path, args.item_col, args.output_path)
+        model = PopularityModel()
+        model.train(args.train_path, item_col=args.item_col)
+        model.save(args.output_path)
     elif args.command == "predict":
-        predict(args.popularity_path, args.output_path, args.top_k)
+        model = PopularityModel.load(args.model_path)
+        # predictions are independent of sessions
+        predictions = model.predict_sessions([[]], args.top_k)
+        with open(args.output_path, "w") as f:
+            json.dump(predictions, f)
+        print(f"Saved predictions to {args.output_path}")
     else:
         parser.print_help()
 

--- a/SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/baselines/rnn_baseline.py
+++ b/SIGIR_eCommerce_Challenge_2021/task1_session_based_rec/baselines/rnn_baseline.py
@@ -1,0 +1,54 @@
+import argparse
+import json
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+
+from models import RNNRecModel
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="GRU-based session model")
+    subparsers = parser.add_subparsers(dest="command")
+
+    train_parser = subparsers.add_parser("train")
+    train_parser.add_argument("train_path", type=Path, help="Training CSV file")
+    train_parser.add_argument("model_path", type=Path, help="Path to save model")
+    train_parser.add_argument("--session-col", default="session_id")
+    train_parser.add_argument("--item-col", default="product_id")
+    train_parser.add_argument("--epochs", type=int, default=5)
+
+    predict_parser = subparsers.add_parser("predict")
+    predict_parser.add_argument("model_path", type=Path, help="Trained model file")
+    predict_parser.add_argument("interactions_path", type=Path, help="CSV with session interactions")
+    predict_parser.add_argument("output_path", type=Path, help="Path to save predictions JSON")
+    predict_parser.add_argument("--session-col", default="session_id")
+    predict_parser.add_argument("--item-col", default="product_id")
+    predict_parser.add_argument("--top-k", type=int, default=20)
+
+    args = parser.parse_args()
+
+    if args.command == "train":
+        model = RNNRecModel()
+        model.train(
+            args.train_path,
+            session_col=args.session_col,
+            item_col=args.item_col,
+            epochs=args.epochs,
+        )
+        model.save(args.model_path)
+    elif args.command == "predict":
+        model = RNNRecModel.load(args.model_path)
+        df = pd.read_csv(args.interactions_path)
+        sessions = df.groupby(args.session_col)[args.item_col].apply(list).tolist()
+        predictions = model.predict_sessions(sessions, top_k=args.top_k)
+        with open(args.output_path, "w") as f:
+            json.dump(predictions, f)
+        print(f"Saved predictions to {args.output_path}")
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce `models.py` with BaseModel, PopularityModel and new GRURecModel
- refactor `popularity_baseline.py` to use the common interface
- implement new `rnn_baseline.py` using PyTorch
- document both baselines in `README.md`
- update root README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest')*